### PR TITLE
Use the Gradle internal GradleVersion class to parse versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,55 @@
 # gradle-wrapper-wrapper
+
 ![example workflow name](https://github.com/bjornvester/gradle-wrapper-wrapper/workflows/Build/badge.svg)
 
-This project facilitates executing the Gradle wrapper script in a multi-project. 
+This project facilitates executing the Gradle wrapper script in a multi-project.
 
-It is similar to [gdub](https://github.com/gdubw/gdub) (which only works in Bash) and [gw](https://github.com/srs/gw) (which is written in Go and has no released artifacts).
+It is similar to [gng](https://github.com/gdubw/gng) (which only works in Bash) and [gw](https://github.com/srs/gw) (which is written in Go and has no released
+artifacts).
 
-Please see the [gdub](https://github.com/gdubw/gdub) project for a good explanation of some shortcomings of working with the normal wrapper script in a multi-project.
-Also see [Gradle issue #1368](https://github.com/gradle/gradle/issues/1368) for voting on getting the feature built directly into Gradle.
+Please see the [gng](https://github.com/gdubw/gng) project for a good explanation of some shortcomings of working with the normal wrapper script in a
+multi-project. Also see [Gradle issue #1368](https://github.com/gradle/gradle/issues/1368) for voting on getting the feature built directly into Gradle.
 
 ## Using the wrapper-wrapper
-Download the executable from the [release page](https://github.com/bjornvester/gradle-wrapper-wrapper/releases) and put it in a folder of your choice.
-Add the folder to your PATH variable.
 
-You can now type `gw` anywhere in a Gradle multi-project structure to invoke the wrapper script found in the root, just like you would type `gradlew` or `gradle`.
+Download the executable from the [release page](https://github.com/bjornvester/gradle-wrapper-wrapper/releases) and put it in a folder of your choice. Add the
+folder to your PATH variable.
+
+You can now type `gw` anywhere in a Gradle multi-project structure to invoke the wrapper script found in the root, just like you would type `gradlew`
+or `gradle`.
 
 For instance: `gw build` or `gw test`.
 
-It has a some fall-back logic in case there is no wrapper script in the project.
-The search logic for finding a suitable Gradle executable is as follows:
+It has a some fall-back logic in case there is no wrapper script in the project. The search logic for finding a suitable Gradle executable is as follows:
 
 1. Use the `gradlew` script in the current directory if present.
 2. Search in parent directories for a `gradlew` script until found or until it reaches the root.
 3. Use `gradle` on the PATH variable if present.
-4. Use `gradle` from a previously downloaded Wrapper distribution in `[USER_HOME]/.gradle/wrapper/dists`.
-   It will choose the latest version if multiple distributions have been downloaded. 
+4. Use `gradle` from a previously downloaded Wrapper distribution in `[USER_HOME]/.gradle/wrapper/dists`. It will choose the latest version if multiple
+   distributions have been downloaded.
 
 ## Build the project from source
+
 The project uses Gradle for building the wrapper, and GraalVM for creating a native executable.
 
 ### Prerequisites
+
 The requirements for Gradle is just a compatible JDK:
-1. Install a [Java Development Kit](https://adoptopenjdk.net/) version 11.
-   Note that you can use any version that is compatible with the version of Gradle used by the project (so JDK 8 or 14 should be fine too, except maybe for MacOS where you need 11 or higher).
+
+1. Install a [Java Development Kit](https://adoptopenjdk.net/) version 11. Note that you can use any version that is compatible with the version of Gradle used
+   by the project (so JDK 8 or 14 should be fine too, except maybe for MacOS where you need 11 or higher).
 2. Set the environment variable `JAVA_HOME` to point to where you installed the JDK (if this isn't done already).
 
-While GraalVM itself is downloaded automatically as part of the build, it requires a local toolchain.
-For Linux, you need glibc and for Windows a version of MSVS.
-See the [GraalVM installation guide](https://www.graalvm.org/reference-manual/native-image/) for help.
+While GraalVM itself is downloaded automatically as part of the build, it requires a local toolchain. For Linux, you need glibc and for Windows a version of
+MSVS. See the [GraalVM installation guide](https://www.graalvm.org/reference-manual/native-image/) for help.
 
 ### Building it
-Checkout the project.
-Then run `gradlew nativeImage` from the root.
-It will build a distribution for your local platform in `build/graal/` called `gw` or `gw.exe` (depending on the platform).
+
+Checkout the project. Then run `gradlew nativeImage` from the root. It will build a distribution for your local platform in `build/graal/` called `gw`
+or `gw.exe` (depending on the platform).
 
 ### Contributions
+
 Contributions are welcome.
 
 If you create a PR, Github will automatically try to build it.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ repositories {
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation(gradleApi())
 }
 
 graal {
@@ -32,6 +33,7 @@ graal {
     option("-R:MinHeapSize=2m")
     option("-R:MaxHeapSize=10m")
     option("-R:MaxNewSize=1m")
+    option("-H:IncludeResources='org/gradle/build-receipt\\.properties\$'") // Functionally unused, but still read and required by the GradleVersion class
 }
 
 tasks.withType<Wrapper> {

--- a/src/main/kotlin/com/github/bjornvester/gww/App.kt
+++ b/src/main/kotlin/com/github/bjornvester/gww/App.kt
@@ -1,11 +1,11 @@
 package com.github.bjornvester.gww
 
+import org.gradle.util.GradleVersion
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
-import kotlin.math.max
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
@@ -67,7 +67,7 @@ private fun findGradleFromPath(): Path? {
 private fun findGradleFromWrapperDist(): Path? {
     // An example of the directory containing the executable could be: [USER]/.gradle/wrapper/dists/gradle-6.6-bin/dflktxzwamd4bv66q00iv4ga9/gradle-6.6/bin
     val distsPath = getUserHome().resolve(".gradle/wrapper/dists")
-    val executablesMap: MutableMap<Version, Path> = mutableMapOf() // Gradle version to executable path
+    val executablesMap: MutableMap<GradleVersion, Path> = mutableMapOf() // Gradle version to executable path
 
     if (Files.isDirectory(distsPath)) {
         Files.list(distsPath).forEach { distPath ->
@@ -113,36 +113,7 @@ private fun getGradleWrapperName() = if (isWindows()) "gradlew.bat" else "gradle
 
 private fun isWindows() = System.getProperty("os.name").toLowerCase().contains("windows")
 
-private fun getVersionFromGradlePath(path: Path): Version? {
+private fun getVersionFromGradlePath(path: Path): GradleVersion? {
     val versionString = Regex("gradle-([\\d.]*)").matchEntire(path.fileName.toString())?.groupValues?.last()
-    return if (versionString == null) null else Version(versionString)
-}
-
-/**
- * Simple version class. Only supports numbers and does not work with text (e.g. "rc-1").
- */
-private data class Version(val version: String) : Comparable<Version> {
-    override fun compareTo(other: Version): Int {
-        val version1Splits = version.split(".")
-        val version2Splits = other.version.split(".")
-        val maxLengthOfVersionSplits = max(version1Splits.size, version2Splits.size)
-        var comparisonResult = 0
-
-        for (i in 0 until maxLengthOfVersionSplits) {
-            val v1 = if (i < version1Splits.size) version1Splits[i].toInt() else 0
-            val v2 = if (i < version2Splits.size) version2Splits[i].toInt() else 0
-            val compare = v1.compareTo(v2)
-
-            if (compare != 0) {
-                comparisonResult = compare
-                break
-            }
-        }
-
-        return comparisonResult
-    }
-
-    override fun toString(): String {
-        return version
-    }
+    return if (versionString == null) null else GradleVersion.version(versionString)
 }


### PR DESCRIPTION
This can compare versions with certain stage names (e.g. rc or milestone).